### PR TITLE
Add '--no-fallback-messages' flag to silence fallback messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ Sub Commands:
 Options:
   --port=2489                 TCP port number
   --line-ending               Convert Line Ending(CR/CRLF)
-  --allow="0.0.0.0/0,::/0"    Allow IP Range             [Server only]
-  --host="localhost"          Destination hostname       [Client only]
-  --trans-loopback=true       Translate loopback address [open subcommand only]
-  --trans-localfile=true      Translate local file path  [open subcommand only]
+  --allow="0.0.0.0/0,::/0"    Allow IP Range                [Server only]
+  --host="localhost"          Destination hostname          [Client only]
+  --no-fallback-messages      Do not show fallback messages [Client only]
+  --trans-loopback=true       Translate loopback address    [open subcommand only]
+  --trans-localfile=true      Translate local file path     [open subcommand only]
   --help                      Show this message
 ```
 

--- a/client/client.go
+++ b/client/client.go
@@ -15,16 +15,18 @@ import (
 )
 
 type client struct {
-	host       string
-	port       int
-	lineEnding string
+	host               string
+	port               int
+	lineEnding         string
+	noFallbackMessages bool
 }
 
 func New(c *lemon.CLI) *client {
 	return &client{
-		host:       c.Host,
-		port:       c.Port,
-		lineEnding: c.LineEnding,
+		host:               c.Host,
+		port:               c.Port,
+		lineEnding:         c.LineEnding,
+		noFallbackMessages: c.NoFallbackMessages,
 	}
 }
 
@@ -109,8 +111,10 @@ func (c *client) Copy(text string) error {
 func (c *client) withRPCClient(f func(*rpc.Client) error) error {
 	rc, err := rpc.Dial("tcp", fmt.Sprintf("%s:%d", c.host, c.port))
 	if err != nil {
-		log.Println(err)
-		log.Println("Fall back to localhost")
+		if !c.noFallbackMessages {
+			log.Println(err)
+			log.Println("Fall back to localhost")
+		}
 		rc, err = c.fallbackLocal()
 		if err != nil {
 			return err

--- a/lemon/cli.go
+++ b/lemon/cli.go
@@ -42,4 +42,6 @@ type CLI struct {
 	LineEnding     string
 
 	Help bool
+
+	NoFallbackMessages bool
 }

--- a/lemon/flag.go
+++ b/lemon/flag.go
@@ -74,6 +74,7 @@ func (c *CLI) flags() *flag.FlagSet {
 	flags.BoolVar(&c.Help, "help", false, "Show this message")
 	flags.BoolVar(&c.TransLoopback, "trans-loopback", true, "Translate loopback address")
 	flags.BoolVar(&c.TransLocalfile, "trans-localfile", true, "Translate local file")
+	flags.BoolVar(&c.NoFallbackMessages, "no-fallback-messages", false, "Do not show fallback messages")
 	flags.StringVar(&c.LineEnding, "line-ending", "", "Convert Line Ending(CR/CRLF)")
 	return flags
 }

--- a/lemon/flag.go
+++ b/lemon/flag.go
@@ -10,7 +10,7 @@ import (
 	"github.com/monochromegane/conflag"
 )
 
-func (c *CLI) FlagParse(args []string) error {
+func (c *CLI) FlagParse(args []string, skip bool) error {
 	style, err := c.getCommandType(args)
 	if err != nil {
 		return err
@@ -19,7 +19,7 @@ func (c *CLI) FlagParse(args []string) error {
 		args = args[:len(args)-1]
 	}
 
-	return c.parse(args)
+	return c.parse(args, skip)
 }
 
 func (c *CLI) getCommandType(args []string) (s CommandStyle, err error) {
@@ -78,11 +78,11 @@ func (c *CLI) flags() *flag.FlagSet {
 	return flags
 }
 
-func (c *CLI) parse(args []string) error {
+func (c *CLI) parse(args []string, skip bool) error {
 	flags := c.flags()
 
 	confPath, err := homedir.Expand("~/.config/lemonade.toml")
-	if err == nil {
+	if err == nil && !skip {
 		if confArgs, err := conflag.ArgsFrom(confPath); err == nil {
 			flags.Parse(confArgs)
 		}

--- a/lemon/flag_test.go
+++ b/lemon/flag_test.go
@@ -161,4 +161,25 @@ func TestCLIParse(t *testing.T) {
 		TransLoopback:  true,
 		TransLocalfile: true,
 	})
+
+	assert([]string{"lemonade", "copy", "--no-fallback-messages", "hogefuga"}, CLI{
+		Type:               COPY,
+		Host:               defaultHost,
+		Port:               defaultPort,
+		Allow:              defaultAllow,
+		DataSource:         "hogefuga",
+		TransLoopback:      true,
+		TransLocalfile:     true,
+		NoFallbackMessages: true,
+	})
+
+	assert([]string{"lemonade", "paste", "--no-fallback-messages"}, CLI{
+		Type:               PASTE,
+		Host:               defaultHost,
+		Port:               defaultPort,
+		Allow:              defaultAllow,
+		TransLoopback:      true,
+		TransLocalfile:     true,
+		NoFallbackMessages: true,
+	})
 }

--- a/lemon/flag_test.go
+++ b/lemon/flag_test.go
@@ -10,7 +10,7 @@ func TestCLIParse(t *testing.T) {
 	assert := func(args []string, expected CLI) {
 		expected.In = os.Stdin
 		c := &CLI{In: os.Stdin}
-		c.FlagParse(args)
+		c.FlagParse(args, true)
 
 		if !reflect.DeepEqual(expected, *c) {
 			t.Errorf("Expected:\n %+v, but got\n %+v", expected, c)

--- a/lemon/main.go
+++ b/lemon/main.go
@@ -17,10 +17,11 @@ Sub Commands:
 Options:
   --port=2489                 TCP port number
   --line-ending               Convert Line Ending(CR/CRLF)
-  --allow="0.0.0.0/0,::/0"    Allow IP Range             [Server only]
-  --host="localhost"          Destination hostname       [Client only]
-  --trans-loopback=true       Translate loopback address [open subcommand only]
-  --trans-localfile=true      Translate local file path  [open subcommand only]
+  --allow="0.0.0.0/0,::/0"    Allow IP Range                [Server only]
+  --host="localhost"          Destination hostname          [Client only]
+  --no-fallback-messages      Do not show fallback messages [Client only]
+  --trans-loopback=true       Translate loopback address    [open subcommand only]
+  --trans-localfile=true      Translate local file path     [open subcommand only]
   --help                      Show this message
 
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 }
 
 func Do(c *lemon.CLI, args []string) int {
-	if err := c.FlagParse(args); err != nil {
+	if err := c.FlagParse(args, false); err != nil {
 		writeError(c, err)
 		return lemon.FlagParseError
 	}


### PR DESCRIPTION
Currently, fallback messages are always shown when the lemonade server is down.

I understand that it is quite important to tell what happens to the users.
However, I often found that the messages are bit annoying, especially when I
use lemonade as a clipboard program of neovim by manually assign `g:clipboard`.

So I added '--no-fallback-messages' flag to silence this warning like:

```
    $ echo 'hello' | pbcopy

    $ ./lemonade paste --host="127.0.0.1" --no-fallback-messages
    hello

    $ ./lemonade paste --host="127.0.0.1"
    2018/01/24 06:05:37 dial tcp 127.0.0.1:2489: getsockopt: connection refused
    2018/01/24 06:05:37 Fall back to localhost
    hello
```

This commit fixes #27