### PR TITLE
Add support for setting an output file for logs instead of stdout

### DIFF
--- a/lemon/cli.go
+++ b/lemon/cli.go
@@ -45,6 +45,7 @@ type CLI struct {
 	LineEnding     string
 	LogLevel       int
 	Timeout        time.Duration
+	LogFile        string
 
 	Help bool
 

--- a/lemon/flag.go
+++ b/lemon/flag.go
@@ -79,6 +79,7 @@ func (c *CLI) flags() *flag.FlagSet {
 	flags.BoolVar(&c.NoFallbackMessages, "no-fallback-messages", false, "Do not show fallback messages")
 	flags.DurationVar(&c.Timeout, "rpc-timeout", 100*time.Millisecond, "RPC timeout")
 	flags.IntVar(&c.LogLevel, "log-level", 1, "Log level")
+	flags.StringVar(&c.LogFile, "log-file", "", "Log output to a file")
 	return flags
 }
 

--- a/lemon/main.go
+++ b/lemon/main.go
@@ -23,6 +23,7 @@ Options:
   --trans-loopback=true       Translate loopback address    [open subcommand only]
   --trans-localfile=true      Translate local file path     [open subcommand only]
   --log-level=1               Log level                     [4 = Critical, 0 = Debug]
+  --log-file=.lemonlog[.json] Output logs to a custom file instead of stdout
   --help                      Show this message
 
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	log "github.com/inconshreveable/log15"
 
@@ -39,7 +40,15 @@ func Do(c *lemon.CLI, args []string) int {
 	}
 
 	logLevel := logLevelMap[c.LogLevel]
-	logger.SetHandler(log.LvlFilterHandler(logLevel, log.StdoutHandler))
+	logOutHandler := log.StdoutHandler
+	if len(c.LogFile) > 0 {
+		logFormat := log.LogfmtFormat()
+		if strings.HasSuffix(c.LogFile, ".json") {
+			logFormat = log.JsonFormat()
+		}
+		logOutHandler = log.Must.FileHandler(c.LogFile, logFormat)
+	}
+	logger.SetHandler(log.LvlFilterHandler(logLevel, logOutHandler))
 
 	if c.Help {
 		fmt.Fprint(c.Err, lemon.Usage)


### PR DESCRIPTION
Add command line flag '--log-file' to output to a logfile.
Use LogfmtFormat by default.
Use JsonFormat if logfile ends in '.json'.