### PR TITLE
Allow Tmux send keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /lemonade
 /dist/
 /pkg/
+.aider*

--- a/client/client.go
+++ b/client/client.go
@@ -129,6 +129,21 @@ func (c *client) withRPCClient(f func(*rpc.Client) error) error {
 	return f(rc)
 }
 
+func (c *client) TmuxSendKeys(target, keys string) error {
+	c.logger.Debug("Sending tmux keys", "target", target, "keys", keys)
+	return c.withRPCClient(func(rc *rpc.Client) error {
+		p := &param.TmuxSendKeysParam{
+			Target: target,
+			Keys:   keys,
+		}
+		err := rc.Call("Tmux.SendKeys", p, dummy)
+		if err != nil {
+			c.logger.Error("Tmux.SendKeys failed", "error", err)
+		}
+		return err
+	})
+}
+
 func (c *client) fallbackLocal() (net.Conn, error) {
 	port, err := server.ServeLocal(c.logger)
 	server.LineEndingOpt = c.lineEnding

--- a/lemon/cli.go
+++ b/lemon/cli.go
@@ -13,6 +13,7 @@ const (
 	COPY
 	PASTE
 	SERVER
+	TMUX
 )
 
 const (
@@ -45,6 +46,8 @@ type CLI struct {
 	LineEnding     string
 	LogLevel       int
 	Timeout        time.Duration
+	TmuxTarget     string
+	TmuxKeys       string
 
 	Help bool
 

--- a/lemon/flag.go
+++ b/lemon/flag.go
@@ -61,6 +61,10 @@ func (c *CLI) getCommandType(args []string) (s CommandStyle, err error) {
 			c.Type = SERVER
 			del(i)
 			return
+		case "tmux":
+			c.Type = TMUX
+			del(i)
+			return
 		}
 	}
 
@@ -79,6 +83,9 @@ func (c *CLI) flags() *flag.FlagSet {
 	flags.BoolVar(&c.NoFallbackMessages, "no-fallback-messages", false, "Do not show fallback messages")
 	flags.DurationVar(&c.Timeout, "rpc-timeout", 100*time.Millisecond, "RPC timeout")
 	flags.IntVar(&c.LogLevel, "log-level", 1, "Log level")
+
+	flags.StringVar(&c.TmuxTarget, "tmux-target", "", "tmux target (session:window.pane)")
+	flags.StringVar(&c.TmuxKeys, "tmux-keys", "", "keys to send to tmux")
 	return flags
 }
 
@@ -98,6 +105,10 @@ func (c *CLI) parse(args []string, skip bool) error {
 		return err
 	}
 	if c.Type == PASTE || c.Type == SERVER {
+		return nil
+	}
+	if c.Type == TMUX {
+		// For tmux command, we expect --tmux-target and --tmux-keys flags
 		return nil
 	}
 

--- a/lemon/flag_test.go
+++ b/lemon/flag_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestCLIParse(t *testing.T) {
@@ -21,6 +22,7 @@ func TestCLIParse(t *testing.T) {
 	defaultHost := "localhost"
 	defaultAllow := "0.0.0.0/0,::/0"
 	defaultLogLevel := 1
+	defaultTimeout := 100 * time.Millisecond
 
 	assert([]string{"xdg-open", "http://example.com"}, CLI{
 		Type:           OPEN,
@@ -30,6 +32,7 @@ func TestCLIParse(t *testing.T) {
 		DataSource:     "http://example.com",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -41,6 +44,7 @@ func TestCLIParse(t *testing.T) {
 		DataSource:     "http://example.com",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -51,6 +55,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -61,6 +66,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -71,6 +77,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -82,6 +89,7 @@ func TestCLIParse(t *testing.T) {
 		DataSource:     "hogefuga",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -93,6 +101,7 @@ func TestCLIParse(t *testing.T) {
 		DataSource:     "hogefuga",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -104,6 +113,7 @@ func TestCLIParse(t *testing.T) {
 		DataSource:     "http://example.com",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -115,6 +125,7 @@ func TestCLIParse(t *testing.T) {
 		DataSource:     "hogefuga",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -125,6 +136,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -135,6 +147,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          "192.168.0.0/24",
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -145,6 +158,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  false,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -155,6 +169,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -165,6 +180,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: false,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -175,6 +191,7 @@ func TestCLIParse(t *testing.T) {
 		Allow:          defaultAllow,
 		TransLoopback:  true,
 		TransLocalfile: true,
+		Timeout:        defaultTimeout,
 		LogLevel:       defaultLogLevel,
 	})
 
@@ -187,6 +204,7 @@ func TestCLIParse(t *testing.T) {
 		TransLoopback:      true,
 		TransLocalfile:     true,
 		NoFallbackMessages: true,
+		Timeout:            defaultTimeout,
 		LogLevel:           defaultLogLevel,
 	})
 
@@ -198,6 +216,20 @@ func TestCLIParse(t *testing.T) {
 		TransLoopback:      true,
 		TransLocalfile:     true,
 		NoFallbackMessages: true,
+		Timeout:            defaultTimeout,
 		LogLevel:           defaultLogLevel,
+	})
+
+	assert([]string{"lemonade", "tmux", "--tmux-target", "session:0.0", "--tmux-keys", "echo 'hello'"}, CLI{
+		Type:           TMUX,
+		Host:           defaultHost,
+		Port:           defaultPort,
+		Allow:          defaultAllow,
+		TransLoopback:  true,
+		TransLocalfile: true,
+		LogLevel:       defaultLogLevel,
+		Timeout:        defaultTimeout,
+		TmuxTarget:     "session:0.0",
+		TmuxKeys:       "echo 'hello'",
 	})
 }

--- a/main.go
+++ b/main.go
@@ -62,9 +62,9 @@ func Do(c *lemon.CLI, args []string) int {
 		text, err = lc.Paste()
 		c.Out.Write([]byte(text))
 	case lemon.TMUX:
-		logger.Info("Sending keys to tmux")
+		logger.Debug("Sending keys to tmux")
 		err = lc.TmuxSendKeys(c.TmuxTarget, c.TmuxKeys)
-		logger.Info("Sent keys to tmux")
+		logger.Debug("Sent keys to tmux")
 	case lemon.SERVER:
 		logger.Debug("Starting Server")
 		err = server.Serve(c, logger)

--- a/main.go
+++ b/main.go
@@ -61,6 +61,10 @@ func Do(c *lemon.CLI, args []string) int {
 		var text string
 		text, err = lc.Paste()
 		c.Out.Write([]byte(text))
+	case lemon.TMUX:
+		logger.Info("Sending keys to tmux")
+		err = lc.TmuxSendKeys(c.TmuxTarget, c.TmuxKeys)
+		logger.Info("Sent keys to tmux")
 	case lemon.SERVER:
 		logger.Debug("Starting Server")
 		err = server.Serve(c, logger)

--- a/param/param.go
+++ b/param/param.go
@@ -4,3 +4,8 @@ type OpenParam struct {
 	URI           string
 	TransLoopback bool
 }
+
+type TmuxSendKeysParam struct {
+	Target string
+	Keys   string
+}

--- a/server/server.go
+++ b/server/server.go
@@ -41,9 +41,13 @@ func Serve(c *lemon.CLI, logger log.Logger) error {
 		}
 		logger.Info("Request from " + conn.RemoteAddr().String())
 		if !ra.InlucdeConn(conn) {
+			logger.Warn("Connection refused because it's not in the allowed IP range.")
 			continue
 		}
+		logger.Debug("Sending connection to channel...")
+
 		connCh <- conn
+		logger.Debug("Sent connection to channel")
 		rpc.ServeConn(conn)
 	}
 }
@@ -51,6 +55,7 @@ func Serve(c *lemon.CLI, logger log.Logger) error {
 // ServeLocal is for fall back when lemonade client can't connect to server.
 // returns port number, error
 func ServeLocal(logger log.Logger) (int, error) {
+	logger.Debug("Falling back to local server")
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
@@ -74,4 +79,6 @@ func init() {
 	rpc.Register(uri)
 	clipboard := &Clipboard{}
 	rpc.Register(clipboard)
+	tmux := &Tmux{}
+	rpc.Register(tmux)
 }

--- a/server/tmux.go
+++ b/server/tmux.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/lemonade-command/lemonade/param"
+)
+
+type Tmux struct{}
+
+func (_ *Tmux) SendKeys(p *param.TmuxSendKeysParam, _ *struct{}) error {
+	<-connCh
+	log.Printf("SendKeys: %v", p)
+	tmuxPath := "/opt/homebrew/bin/tmux"
+	cmd := exec.Command(tmuxPath, "send-keys", "-t", p.Target, p.Keys)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error running tmux command: %v", err)
+		log.Printf("Command output: %s", string(output))
+		return fmt.Errorf("tmux command failed: %v (output: %s)", err, string(output))
+	}
+
+	log.Printf("Tmux command executed successfully. Output: %s", string(output))
+
+	return nil
+
+}


### PR DESCRIPTION
Support use case where tmux is used and one program in one pane is used to control another program in another pane. 

Example:

`lf` is used for file management and when `o` is pressed, it should open up the file in vim in `pane 0` 
